### PR TITLE
Removes deprecated @angular/http package

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,6 @@
     "@angular/core": "^9.1.6",
     "@angular/flex-layout": "^9.0.0-beta.29",
     "@angular/forms": "^9.1.6",
-    "@angular/http": "^7.2.16",
     "@angular/material": "^9.2.3",
     "@angular/platform-browser": "^9.1.6",
     "@angular/platform-browser-dynamic": "^9.1.6",

--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -6,7 +6,7 @@ import { AppComponent } from './app.component';
 import { CustomMaterialModule } from './modules/custom-material/custom-material.module';
 import { HeaderComponent } from './components/header/header.component';
 import { ContentComponent } from './components/content/content.component';
-import { HttpModule } from '@angular/http';
+import { HttpClientModule } from '@angular/common/http';
 
 import { YogiBotService } from './services/yogi-bot.service';
 import { SayingService } from './services/saying.service';
@@ -26,7 +26,7 @@ import { Angulartics2Module, Angulartics2GoogleAnalytics, Angulartics2Piwik } fr
   imports: [
     BrowserModule,
     CustomMaterialModule,
-    HttpModule,
+    HttpClientModule,
     CountryModule,
     FormsModule,
     ReactiveFormsModule,

--- a/src/app/services/saying.service.ts
+++ b/src/app/services/saying.service.ts
@@ -1,13 +1,12 @@
 import { Injectable, Inject } from '@angular/core';
 import { COUNTRIES_DATA, Countries, LANGUAGES_DATA, Languages } from '../modules/country/models';
-import { Http } from '@angular/http';
-import { Observable } from 'rxjs/Observable';
 
 import 'rxjs/add/operator/toPromise';
 import * as _ from 'lodash';
 
 import { Saying } from '../models/saying';
 import { YogiBotService } from './yogi-bot.service';
+import { HttpClient } from '@angular/common/http';
 
 export interface Language {
   name: string;
@@ -35,7 +34,7 @@ export class SayingService {
   count = 0;
 
   constructor(
-    private http: Http,
+    private httpClient: HttpClient,
     private yogibot: YogiBotService,
     @Inject(COUNTRIES_DATA) private countriesData: Countries,
     @Inject(LANGUAGES_DATA) private languagesData: Languages
@@ -50,11 +49,11 @@ export class SayingService {
 
   // use ipinfo to get client's country code and get language
   setCurrentLanguageIndex(): void {
-    this.http
-      .get('https://ipinfo.io/json')
+    this.httpClient
+      .get<any>('https://ipinfo.io/json')
       .toPromise()
       .then(response => {
-        const countryCode = response.json().country;
+        const countryCode = response.country;
         const currentLangs = _.values(this.countriesData[countryCode].languages);
         // check if this language is supported
         const lang = _.findKey(this.supportLanguages, _.partial(_.isEqual, currentLangs));

--- a/src/app/services/yogi-bot.service.ts
+++ b/src/app/services/yogi-bot.service.ts
@@ -1,21 +1,20 @@
 import { Injectable } from '@angular/core';
-import { Http } from '@angular/http';
-import { Observable } from 'rxjs/Observable';
 
 import 'rxjs/add/operator/toPromise';
 import { Saying } from '../models/saying';
+import { HttpClient } from '@angular/common/http';
 
 // Service to get Saying from YogiBot
 @Injectable()
 export class YogiBotService {
 
-  constructor(private http: Http) { }
+  constructor(private httpClient: HttpClient) { }
 
   getSaying(language: string): Promise<Saying> {
-    return this.http
+    return this.httpClient
       .get('https://poopjournal.rocks/YogiBot/API/v2/api.php?command=get_random_one&lng=' + language)
       .toPromise()
-      .then(response => response.json()[0] as Saying)
+      .then(response => response[0] as Saying)
       .catch(this.handleError);
   }
 


### PR DESCRIPTION
This PR solves #82 

This PR removes the deprecated `@angular/http` package and replaces it with `@angular/common/http`. 